### PR TITLE
🐛 getMeUtU Bugfix 🐛 Squeeze trailing dimension

### DIFF
--- a/pykilosort/learn.py
+++ b/pykilosort/learn.py
@@ -143,7 +143,7 @@ def getMeUtU(iU, iC, mask, Nnearest, Nchan):
     U = np.zeros((Nchan, Nfilt), dtype=np.float32, order='F')
 
     # use the template primary channel to obtain its neighboring channels from iC
-    ix = cp.asnumpy(iC[:, iU]) + np.arange(0, Nchan * Nfilt, Nchan).astype(np.int32)
+    ix = cp.asnumpy(iC[:, iU]).squeeze() + np.arange(0, Nchan * Nfilt, Nchan).astype(np.int32)
     # WARNING: transpose because the indexing assumes F ordering.
     U.T.flat[ix] = 1  # use this as an awkward index into U
 


### PR DESCRIPTION
Without this dimension squeezed the range is added to the trailing dimension instead of the second one. Because the index `ix` is only used in the assignment in the next line (and all the values remain within the bounds of `len(U)` this will never error but silently give the wrong result!

See `getMeUtU` block of notebook in https://github.com/alexmorley/kilosort-testing/compare/main...learntemplates-tests?expand=1&title=Tests+for+main+learning+loop+and+its+constituent+parts+-+WIP for test.