### PR TITLE
Add raw_probe variable for gui plotting 

### DIFF
--- a/pykilosort/main.py
+++ b/pykilosort/main.py
@@ -11,7 +11,7 @@ from .preprocess import preprocess, get_good_channels, get_whitening_matrix, get
 from .cluster import clusterSingleBatches
 from .learn import learnAndSolve8b
 from .postprocess import find_merges, splitAllClusters, set_cutoff, rezToPhy
-from .utils import Bunch, Context, memmap_large_array, load_probe
+from .utils import Bunch, Context, memmap_large_array, load_probe, copy_bunch
 from .params import KilosortParams
 
 logger = logging.getLogger(__name__)
@@ -81,6 +81,7 @@ def run(
     ctx = Context(ctx_path)
     ctx.params = params
     ctx.probe = probe
+    ctx.raw_probe = copy_bunch(probe)
     ctx.raw_data = raw_data
 
     # Load the intermediate results to avoid recomputing things.

--- a/pykilosort/utils.py
+++ b/pykilosort/utils.py
@@ -35,6 +35,24 @@ class Bunch(dict):
         return Bunch(super(Bunch, self).copy())
 
 
+def copy_bunch(old_bunch):
+    """
+    A function to copy a bunch object with a deep copy of numpy arrays
+    :param old_bunch: Bunch object to be copied
+    :return: New Bunch object
+    """
+    assert isinstance(old_bunch, Bunch)
+
+    new_bunch = Bunch()
+    for key in old_bunch.keys():
+        if type(old_bunch[key]) == np.ndarray:
+            new_bunch[key] = old_bunch[key].copy()
+        else:
+            new_bunch[key] = old_bunch[key]
+
+    return new_bunch
+
+
 def p(x):
     print("shape", x.shape, "mean", "%5e" % x.mean())
     print(x[:2, :2])


### PR DESCRIPTION
Channels with low firing rates are removed from the probe which can lead to problems when plotting results in the GUI. Now a new variable raw_probe is saved to remember the layout before any channels are forgotten.