### PR TITLE
fixes deprecated syntax for newer numpy versions

### DIFF
--- a/pykilosort/cptools.py
+++ b/pykilosort/cptools.py
@@ -390,7 +390,7 @@ def median(a, axis=0):
     else:
         indexer[axis] = slice(index - 1, index + 1)
 
-    return cp.mean(part[indexer], axis=axis)
+    return cp.mean(part[tuple(indexer)], axis=axis)
 
 
 def var(x):


### PR DESCRIPTION
Newer numpy (and by extension cupy) versions have deprecated and then completely dropped support for the multi-indexing done with lists here. Instead, the type used here must be a tuple to be compatible with newer numpy versions.