### PR TITLE
fixes deprecated syntax for numpy

### DIFF
--- a/pykilosort/cptools.py
+++ b/pykilosort/cptools.py
@@ -390,7 +390,7 @@ def median(a, axis=0):
     else:
         indexer[axis] = slice(index - 1, index + 1)
 
-    return cp.mean(part[indexer], axis=axis)
+    return cp.mean(part[tuple(indexer)], axis=axis)
 
 
 def var(x):

--- a/pykilosort/utils.py
+++ b/pykilosort/utils.py
@@ -72,7 +72,7 @@ def _extend(x, i0, i1, val, axis=0):
         assert x.shape[axis] == i1
     s = [slice(None, None, None)] * x.ndim
     s[axis] = slice(i0, i1, 1)
-    x[s] = val
+    x[tuple(s)] = val
     for i in range(x.ndim):
         if i != axis:
             assert x.shape[i] == shape[i]


### PR DESCRIPTION
Newer numpy (and by extension cupy) versions have deprecated and then completely dropped support for the multi-indexing done with lists here. Instead, the type used here must be a tuple to be compatible with newer numpy versions.

Previous issue was accidentally closed because of a branch rename.