### PR TITLE
Create manifest to include cuda files and others

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include requirements.txt
+include README.md
+include LICENSE
+include pykilosort/cuda/*


### PR DESCRIPTION
Fixes the cuda shader files not being present when installing with pip. 
Also includes other important files like requirements.txt and the license.

Should fix #69
