### PR TITLE
Added type annotation to ntbuff in params.py

### DIFF
--- a/pykilosort/params.py
+++ b/pykilosort/params.py
@@ -191,7 +191,7 @@ class KilosortParams(BaseModel):
     nfilt_factor: int = Field(
         4, description="max number of clusters per good channel (even temporary ones)"
     )
-    ntbuff = Field(
+    ntbuff: int = Field(
         64,
         description="""
     samples of symmetrical buffer for whitening and spike detection


### PR DESCRIPTION
Error thrown during import by pydantic since type annotation was missing for field 'ntbuff' in params.py. Simple fix.

```
import pykilosort
  File "<stdin>", line 1, in <module>
  File "pykilosort/__init__.py", line 12, in <module>
    from .main import run, run_export, run_spikesort, run_preprocess
  File "site-packages/pykilosort/main.py", line 14, in <module>
    from .params import KilosortParams
  File "site-packages/pykilosort/params.py", line 63, in <module>
    class KilosortParams(BaseModel):
  File "site-packages/pydantic/_internal/_model_construction.py", line 95, in __new__
    private_attributes = inspect_namespace(
  File "site-packages/pydantic/_internal/_model_construction.py", line 324, in inspect_namespace
    raise PydanticUserError(
pydantic.errors.PydanticUserError: Field 'ntbuff' requires a type annotation
```